### PR TITLE
Default region for kms client bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-translations-webpack-plugin",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Effortless webpack integration with Cimpress Translations Service",
   "main": "./lib/index.js",
   "files": [

--- a/src/kmsClientIdAuthorizer.js
+++ b/src/kmsClientIdAuthorizer.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const AWS = require("aws-sdk");
-const KMS = new AWS.KMS();
 const jwt = require("jsonwebtoken");
 
 const Auth0Authenticator = require("./auth0Authenticator");
@@ -11,17 +10,15 @@ class kmsClientIdAuthorizer {
     this.clientId = clientId;
     this.encryptedClientSecret = encryptedClientSecret;
     this.defaultRegion = defaultRegion;
+    this.KMS = new AWS.KMS(this.defaultRegion ? { region: this.defaultRegion} : {});
 
     this.token = null;
     this.authenticator = null;
   }
 
   async init() {
-    if(this.defaultRegion) {
-      AWS.config.update({ region: this.defaultRegion });
-    }
     let params = { CiphertextBlob: new Buffer(this.encryptedClientSecret, "base64") };
-    let data = await KMS.decrypt(params).promise();
+    let data = await this.KMS.decrypt(params).promise();
 
     this.authenticator = new Auth0Authenticator("cimpress.auth0.com", this.clientId, data.Plaintext.toString());
   }


### PR DESCRIPTION
Turns out that you need to init the kms client with the default region specified in the options parameter