### PR TITLE
Remove AWS sdk from strict dependencies. fix #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Built-in authorization modules can be found under CimpressTranslationsWebpackPlu
 
 ##### kmsClientIdAuthorizer(clientId, encryptedClientSecret)
 
-The module uses the Client Credentials Grant authentication flow to obtain a valid access token. An encrypted client secret is stored in your webpack configuration and is decrypted using AWS KMS.
+The module uses the Client Credentials Grant authentication flow to obtain a valid access token. An encrypted client secret is stored in your webpack configuration and is decrypted using AWS KMS.  To configure KMS import `aws-sdk` and set the aws configuration directly. The `aws-sdk` configuration will be reused in this library.
 
 ## Live development
 

--- a/__test__/package.json.test.js
+++ b/__test__/package.json.test.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const assert = require("assert");
+const path = require("path");
+
+const packageMetadata = require('../package.json');
+
+describe("for package.json", () => {
+  // For AWS client configuration to work, the library must configure it as a peer dependency. This is because if a different version of the AWS SDK library is used in here and in the clients code,
+  // two different instances of the AWS SDK will be created, each with different configuration. Making this a peer dependency allows the client to configure the AWS SDK directly.
+  it("aws should be a peer dependency", () => {
+    assert.equal(packageMetadata.peerDependencies['aws-sdk'], '*');
+  });
+  it("aws should not be a direct dependency", () => {
+    assert.equal(packageMetadata.dependencies['aws-sdk'], null);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-translations-webpack-plugin",
-  "version": "1.1.10",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -265,6 +265,7 @@
       "version": "2.286.2",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.286.2.tgz",
       "integrity": "sha512-46a/2+rGEgIlmUz08vZOkYFmZIgj+An/cc+Ngz9XBLkAZbx+3sBzOrxexrlVV69MPkMbckbeZjIq8NEJWV5gPw==",
+      "dev": true,
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -280,12 +281,14 @@
         "sax": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+          "dev": true
         },
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "dev": true
         }
       }
     },
@@ -1083,7 +1086,8 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1177,6 +1181,7 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -1899,7 +1904,8 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.2.2",
@@ -2340,12 +2346,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2360,17 +2368,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2487,7 +2498,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2499,6 +2511,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2513,6 +2526,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2520,12 +2534,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2544,6 +2560,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2624,7 +2641,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2636,6 +2654,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2757,6 +2776,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3100,7 +3120,8 @@
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
     },
     "import-local": {
       "version": "1.0.0",
@@ -4250,7 +4271,8 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -5279,7 +5301,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "randomatic": {
       "version": "3.0.0",
@@ -5949,7 +5972,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "semver": {
       "version": "5.5.0",
@@ -7010,6 +7034,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -7018,7 +7043,8 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
         }
       }
     },
@@ -7290,6 +7316,7 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
@@ -7298,7 +7325,8 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-translations-webpack-plugin",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Effortless webpack integration with Cimpress Translations Service",
   "main": "./lib/index.js",
   "files": [
@@ -37,7 +37,6 @@
   },
   "homepage": "https://github.com/Cimpress/cimpress-translations-webpack-plugin#readme",
   "dependencies": {
-    "aws-sdk": "^2.286.2",
     "body-parser": "^1.18.3",
     "cimpress-translations": "^2.0.2",
     "cors": "^2.8.4",
@@ -47,6 +46,7 @@
     "winston": "^3.0.0-rc5"
   },
   "devDependencies": {
+    "aws-sdk": "^2.286.2",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.26.0",
@@ -55,6 +55,6 @@
     "supertest": "^3.1.0"
   },
   "peerDependencies": {
-    "aws-sdk": "2.x"
+    "aws-sdk": "*"
   }
 }

--- a/src/kmsClientIdAuthorizer.js
+++ b/src/kmsClientIdAuthorizer.js
@@ -6,11 +6,10 @@ const jwt = require("jsonwebtoken");
 const Auth0Authenticator = require("./auth0Authenticator");
 
 class kmsClientIdAuthorizer {
-  constructor(clientId, encryptedClientSecret, defaultRegion = null) {
+  constructor(clientId, encryptedClientSecret) {
     this.clientId = clientId;
     this.encryptedClientSecret = encryptedClientSecret;
-    this.defaultRegion = defaultRegion;
-    this.KMS = new AWS.KMS(this.defaultRegion ? { region: this.defaultRegion} : {});
+    this.KMS = new AWS.KMS();
 
     this.token = null;
     this.authenticator = null;


### PR DESCRIPTION
It turns out that we had a regression in the setup of translations.  The AWS SDK being used needs to be the same one which the client is using otherwise there is not a good way to update the aws settings.  It seems we started to go down the path of explicitly requiring passing in all the settings to the library.  Instead we can easily avoid providing a wrapper around AWS by allowing the client to configure AWS directly.  For this to work, we need to make sure that the library doesn't explicitly require a version of AWS, but instead specifies it as a `peer-dependency`.

It turns out that was already the case, but some how it got into to the `package.json` which broke the functionality.  The "fix in #7" tried to work around this problem, but actually reintroduced the original issue.  I've added a unit test to prevent this problem.

Additionally, because this is a breaking change, technically in the library, I have increased the major version.  If anyone thinks that this is actually a bug fix, I'm happy to revert that change.